### PR TITLE
Add author to the posts

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,6 @@
 baseurl = "https://blog.coredns.io/"
 languageCode = "en-us"
 title = "CoreDNS News"
-author = "CoreDNS Authors"
 copyright = "CoreDNS All Rights Reserved"
 theme = "hugo-zen"
 
@@ -15,3 +14,17 @@ theme = "hugo-zen"
 [permalinks]
     post = "/:year/:month/:day/:title/"
     page = "/:title/"
+
+[params.authors.miek]
+  name = "Miek Gieben"
+  location = "London, UK"
+  email = "miek@miek.nl"
+  twitter = "https://twitter.com/miekg"
+  github = "https://github.com/miekg"
+
+[params.authors.john]
+  name = "John Belamaric"
+  location = "Washington, DC"
+  email = "jbelamaric@infoblox.com"
+  twitter = "https://twitter.com/johnbelamaric"
+  github = "https://github.com/johnbelamaric"

--- a/content/post/coredns-001.md
+++ b/content/post/coredns-001.md
@@ -3,6 +3,7 @@ date = "2016-09-18T11:40:37+01:00"
 slug = "CoreDNS-001 Release Notes"
 tags = ["Release", "001", "Notes"]
 title = "CoreDNS-001 Release"
+author = "miek"
 +++
 
 CoreDNS-001 has been [released](https://github.com/coredns/coredns/releases). This is the first

--- a/content/post/coredns-002.md
+++ b/content/post/coredns-002.md
@@ -3,6 +3,7 @@ date = "2016-10-19T19:09:32Z"
 slug = "CoreDNS-002 Release Notes"
 tags = ["Release", "002", "Notes"]
 title = "CoreDNS-002 Release"
+author = "miek"
 +++
 
 CoreDNS-002 has been [released](https://github.com/coredns/coredns/releases)!

--- a/content/post/coredns-003.md
+++ b/content/post/coredns-003.md
@@ -3,6 +3,7 @@ date = "2016-11-11T16:38:32Z"
 slug = "CoreDNS-003 Release Notes"
 tags = ["Release", "003", "Notes"]
 title = "CoreDNS-003 Release"
+author = "miek"
 +++
 
 CoreDNS-003 has been [released](https://github.com/coredns/coredns/releases)!

--- a/content/post/coredns-004.md
+++ b/content/post/coredns-004.md
@@ -3,6 +3,7 @@ date = "2017-01-01T10:30:31Z"
 slug = "CoreDNS-004 Release Notes"
 tags = ["Release", "004", "Notes"]
 title = "CoreDNS-004 Release"
+author = "miek"
 +++
 
 CoreDNS-004 has been [released](https://github.com/coredns/coredns/releases/tag/v004)!

--- a/content/post/coredns-005.md
+++ b/content/post/coredns-005.md
@@ -3,6 +3,7 @@ date = "2017-02-09T18:50:31Z"
 slug = "CoreDNS-005 Release Notes"
 tags = ["Release", "005", "Notes"]
 title = "CoreDNS-005 Release"
+author = "miek"
 +++
 
 CoreDNS-005 has been [released](https://github.com/coredns/coredns/releases/tag/v005)!

--- a/content/post/coredns-and-caddy.md
+++ b/content/post/coredns-and-caddy.md
@@ -3,6 +3,7 @@ date = "2016-09-29T06:18:40Z"
 slug = "CoreDNS can now be downloaded from Caddy's download page"
 tags = ["Caddy", "Bugs", "Questions"]
 title = "Coredns and Caddy"
+author = "miek"
 +++
 [Caddy 0.9.3](https://forum.caddyserver.com/t/caddy-0-9-3-released/725) is released.  On it's
 [download page](https://caddyserver.com/download) you can now select the "DNS plugin" to be added

--- a/content/post/coredns-middleware.md
+++ b/content/post/coredns-middleware.md
@@ -3,6 +3,7 @@ date = "2016-12-19T08:00:24Z"
 slug = "A introduction into writing middleware for CoreDNS"
 tags = ["middleware", "coredns", "plugins"]
 title = "Writing Middleware for CoreDNS"
+author = "miek"
 +++
 
 As CoreDNS uses Caddy for setting up and using middleware, the process of writing middleware is

--- a/content/post/coredns-query-routing.md
+++ b/content/post/coredns-query-routing.md
@@ -3,6 +3,7 @@ date = "2016-10-13T08:50:13Z"
 slug = "Which middleware will handle a query?"
 tags = ["Corefile", "query", "routing"]
 title = "Query Routing"
+author = "miek"
 +++
 
 Quiz time, in the following Corefile:

--- a/content/post/httpsproxy.md
+++ b/content/post/httpsproxy.md
@@ -3,7 +3,7 @@ date = "2016-11-26T17:22:44Z"
 slug = "Using Google's dns.google.com with CoreDNS"
 tags = ["Encryption", "DNS", "Google"]
 title = "DNS over HTTPS"
-
+author = "miek"
 +++
 
 Since almost a year Google has a DNS service that can be queried over HTTPS:

--- a/content/post/kubernetes-service-discovery.md
+++ b/content/post/kubernetes-service-discovery.md
@@ -3,6 +3,7 @@ date = "2016-11-08T07:33:08Z"
 slug = "Using CoreDNS for service discovery in Kubernetes"
 tags = ["Kubernetes", "Service", "Discovery", "Kube-DNS"]
 title = "CoreDNS for Kubernetes Service Discovery"
+author = "miek"
 +++
 
 [Infoblox](https://www.infoblox.com/)'s John Belamaric has published a

--- a/themes/hugo-zen/layouts/_default/single.html
+++ b/themes/hugo-zen/layouts/_default/single.html
@@ -1,12 +1,18 @@
 {{ partial "header.html" . }}
-
+{{ $author := index .Site.Params.authors .Params.author }}
 	<main role="main">
 		<article itemscope itemtype="http://schema.org/BlogPosting">
 			<h1 class="entry-title" itemprop="headline">{{ .Title }}</h1>
 			<span class="entry-meta"><time itemprop="datePublished" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 02, 2006" }}</time>&nbsp;&nbsp;</span>
                 <span class="entry-meta">
                     {{ range $i, $e := .Params.tags }}{{if $i}} &nbsp;{{end}}<a class="meta" href="/tags/{{ . | urlize }}">{{.}}</a>{{ end }}
-                </span>
+                </span><p/>
+		<span class="entry-author">
+		    {{ $author.name }}&nbsp;
+                    {{ with $author.email }}<a href="mailto:{{ . }}" target="_blank">Email</a>&nbsp;{{ end }}
+                    {{ with $author.twitter }}<a href="{{ . }}" target="_blank">Twitter</a>&nbsp;{{ end }}
+                    {{ with $author.github }}<a href="{{ . }}" target="_blank">GitHub</a>&nbsp;{{ end }}
+		</span>
 			<section itemprop="entry-text">
 				{{ .Content }}
 			</section>

--- a/themes/hugo-zen/static/css/custom.css
+++ b/themes/hugo-zen/static/css/custom.css
@@ -55,16 +55,23 @@ main {
   text-decoration: none;
 }
 
+.entry-author {
+  display: inline-block;
+  margin-top: 0;
+  margin-bottom: 2.0rem;
+  font-size: 1.2rem;
+  color: #888;
+}
+
 .entry-meta {
   display: inline-block;
-  margin-bottom: 2rem;
+  margin-bottom: 0;
   font-size: 1.7rem;
   color: #888;
 }
 
 .entry-meta a {
   display: inline-block;
-  margin-bottom: 2rem;
   font-size: small;
   color: #888;
 }


### PR DESCRIPTION
In preparation for more authors than just Miek.

@miekg - I am thinking to do the next K8s blog directly here in the CoreDNS blog, and then link to it from Infoblox's blog.

In preparation, I added an "Authors" section in the config and use it on each post. Let me know what you think.